### PR TITLE
Multiple target individuals per grammar

### DIFF
--- a/examples/synthetic_grammar_ex.py
+++ b/examples/synthetic_grammar_ex.py
@@ -60,6 +60,15 @@ def generate_target_individual(seed: int, grammar, target_depth: int = 10):
     individual_phenotype = representation.genotype_to_phenotype(target_individual)
     return individual_phenotype
 
+def generate_list_of_target_individuals(seed: int, grammar, target_depth: int = 10, number_of_target_individuals: int = 10):
+    """Generates an arbitratry individual that uses a grammar."""
+    r = RandomSource(seed)
+    individuals_phenotype = list()
+    for _ in range(number_of_target_individuals):
+        rand_int = r.randint(1,10000)
+        individuals_phenotype.append(generate_target_individual(rand_int, grammar, target_depth), rand_int)
+    return individuals_phenotype
+
 
 def generate_fitness_functions(grammar: Grammar, target_individual):
     """Generates three fitness_functions for a particular individual"""
@@ -96,8 +105,9 @@ def generate_fitness_functions(grammar: Grammar, target_individual):
     ]
 
 
-def generate_problem(seed: int, target_depth: int):
+def generate_problem(seed: int, target_depth: int, number_of_target_individuals: int = 1):
     """Generates a valid grammar, target_individual and fitness_functions."""
+    assert number_of_target_individuals > 0
     seedx = seed
     for _ in range(30):
         non_terminals_count = random.randint(3, 20)
@@ -116,12 +126,12 @@ def generate_problem(seed: int, target_depth: int):
             print(f"Fail {seedx}")
             continue
         else:
-            target_ind = generate_target_individual(seedx, grammar, target_depth)
-            fitness_functions = generate_fitness_functions(grammar, target_ind)
+            target_inds = generate_list_of_target_individuals(seedx, grammar, target_depth, number_of_target_individuals)
+            fitness_functions = [ generate_fitness_functions(grammar, target_ind) for target_ind,_ in target_inds ]
             return (
                 seedx,
                 grammar,
-                target_ind,
+                target_inds,
                 target_depth,
                 fitness_functions,
                 non_terminals_count,

--- a/examples/utils/wrapper.py
+++ b/examples/utils/wrapper.py
@@ -74,6 +74,7 @@ def single_run(
     base_seed,
     timeout,
     seed,
+    target_ind_seed,
     params,
     grammar: Grammar,
     benchmark_name,
@@ -110,6 +111,7 @@ def single_run(
             "Representation": lambda gen, pop, time, gp, ind: str(repr.__name__),
             "Fitness Difficulty": lambda gen, pop, time, gp, ind: ff_level,
             "Max Depth": lambda gen, pop, time, gp, ind: max_depth,
+            "Target Individual Seed": lambda gen, pop, time, gp, ind: target_ind_seed,
             "Grammar Seed": lambda gen, pop, time, gp, ind: base_seed,
             "GP Seed": lambda gen, pop, time, gp, ind: seed,
             "Grammar": lambda gen, pop, time, gp, ind: grammar,
@@ -131,7 +133,10 @@ def single_run(
             "Requested Recursive Non Terminals Count": lambda gen, pop, time, gp, ind: recursive_non_terminals_count,  #
             "Requested Average Productions per Terminal": lambda gen, pop, time, gp, ind: average_productions_per_terminal,  #
             "Requested Non Terminals per Production": lambda gen, pop, time, gp, ind: non_terminals_per_production,  #
-            "Target Individual": lambda gen, pop, time, gp, ind: str(target_individual),  #
+            # -- Target Individual ------------------
+            # "Target Individual": lambda gen, pop, time, gp, ind: str(target_individual),  # Complete target individual
+            # "Target Individual nodes": lambda gen, pop, time, gp, ind: target_individual.gengy_nodes,  # Number of nodes of target individual
+            # "Target Individual depth": lambda gen, pop, time, gp, ind: target_individual.gengy_distance_to_term,  # Depth of target individual
         },
     )
 
@@ -234,7 +239,7 @@ def run_synthetic_experiments(
     print("benchmark_name", benchmark_name)
     params = make_synthetic_params(seed)
     representation_name, repr = make_representations()[representation_index]
-    ff_level, ff, target_individual = fitness_function
+    ff_level, ff, target_individual[0] = fitness_function
     try:
         single_run(
             base_seed,

--- a/run_synthetic_example.py
+++ b/run_synthetic_example.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     (
         seed,
         grammar,
-        target_individual,
+        target_individuals,
         target_depth,
         fitness_functions,
         non_terminals_count,
@@ -29,18 +29,20 @@ if __name__ == "__main__":
         non_terminals_per_production,
     ) = generate_problem(base_seed, target_depth)
 
-    run_synthetic_experiments(
-        benchmark_name=f"synthetic_{seed}_{target_depth}_{fitness_functions[args.fitness][0]}",
-        base_seed=base_seed,
-        timeout=args.timeout,
-        seed=seed,
-        grammar=grammar,
-        representation_index=args.representation,
-        target_individual=target_individual,
-        target_depth=target_depth,
-        fitness_function=fitness_functions[args.fitness],
-        non_terminals_count=non_terminals_count,
-        recursive_non_terminals_count=recursive_non_terminals_count,
-        average_productions_per_terminal=average_productions_per_terminal,
-        non_terminals_per_production=non_terminals_per_production,
-    )
+    for idx, target_individual in enumerate(target_individuals):
+        run_synthetic_experiments(
+            benchmark_name=f"synthetic_{seed}_{target_depth}_{fitness_functions[args.fitness][0]}_target_ind{idx}",
+            base_seed=base_seed,
+            timeout=args.timeout,
+            seed=seed,
+            target_ind_seed=target_individual[1],
+            grammar=grammar,
+            representation_index=args.representation,
+            target_individual=target_individual[0],
+            target_depth=target_depth,
+            fitness_function=fitness_functions[idx][args.fitness],
+            non_terminals_count=non_terminals_count,
+            recursive_non_terminals_count=recursive_non_terminals_count,
+            average_productions_per_terminal=average_productions_per_terminal,
+            non_terminals_per_production=non_terminals_per_production,
+        )


### PR DESCRIPTION
Hi @alcides,

I discussed this work with Guilherme, and he pointed out that the target individual influences the fitness landscape a lot. Therefore, I suggest to train 10 times with different target individuals for each grammar, to reduce the influence there. Now I'm writing this down, I'm not sure anymore whether this is necessary, though, as we are creating many problems anyway, so that a single problem (grammar + fitness/target_ind) is not very influential. In this branch I created a dummy version to run this (untested). 

What do you think?

Best,
Leon